### PR TITLE
fix: Use gcloud auth directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Based on the author's syscall analysis of docker builds (version 17.12.0-ce), it
 
 # A Solution
 
-This script acts as a proxy for `docker-credential-gcr` credential-helper, intercepting `get` requests and returning the token found in `$HOME/.gcloud/docker_credentials.json` if it is not expired.  This results in order-of-magnitude docker build startup time performance, as long as your environment allows the gcloud active account token to be used.
+This script acts as a proxy for `docker-credential-gcr` credential-helper, intercepting `get` requests and returning the `.gcr-token` cached token if the file is valid and less than an hour old.  Otherwise, the script will perform a manual token refresh using `gcloud config`, and then subsequent requests will be cached.  As crazy as this sounds, this results in order-of-magnitude improvements in startup performance for docker build operations.
 
 # Requirements
 
 - You are using Docker with Google Container Registry, and you can use your active gcloud account for pulling/pushing docker images to GCR.
-- [jq](https://stedolan.github.io/jq/) must be installed and available on your environment PATH.
+- You have `gcloud` CLI tools installed and available on your environment PATH.
 
 # Installation
 
@@ -28,3 +28,14 @@ This script acts as a proxy for `docker-credential-gcr` credential-helper, inter
 3. Change "gcr" to "gcr-cached" in your `$HOME/.docker/config.json` file.
 
 4. Enjoy faster docker builds!
+
+
+# Usage
+
+If you have permissions issues when running docker builds, this could result from having the wrong gcloud account enabled during the first time the script is run.  If you think this has occurred, you can try setting `GCR_AUTH_REFRESH=1` before your `docker` command to force refresh of the token.
+
+Example:
+
+```
+GCR_AUTH_REFRESH=1 docker build -f Dockerfile .
+```

--- a/docker-credential-gcr-cached
+++ b/docker-credential-gcr-cached
@@ -1,14 +1,27 @@
-#!/bin/sh
+#!/bin/bash
 
-DOCKER_CREDS="$HOME/.config/gcloud/docker_credentials.json"
+set -e
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+TOKEN_FILE="$SCRIPT_DIR/.gcr-token"
+
+refresh_token() {
+  gcloud config config-helper --force-auth-refresh --format='value(credential.access_token)' > "$TOKEN_FILE"
+}
+
 if [ "$1" = "get" ]; then
-  if [ -f "$DOCKER_CREDS" ]; then
-    local_date=`date +%Y-%m-%dT%H:%M:%S.%s`
-    expiry=`jq < "$DOCKER_CREDS" '.gcrCreds.token_expiry' -r`
-    if [ "$local_date" \< "$expiry" ]; then
-      jq < "$DOCKER_CREDS" '.gcrCreds | {"Secret": .access_token, "Username": "oauth2accesstoken", "ServerURL": ""}' -M
-      exit 0
+  if [ ! -f "$TOKEN_FILE" ] || [ -n "$GCR_AUTH_REFRESH" ]; then
+    refresh_token
+  else
+    TOKEN_AGE=$(stat -L -f %Y "$TOKEN_FILE")
+    if (( TOKEN_AGE > 3600 )); then
+      refresh_token
     fi
   fi
+
+  token=$(cat "$TOKEN_FILE")
+
+  echo "{\"Secret\": \"$token\", \"Username\": \"oauth2accesstoken\", \"ServerURL\":\"\"}"
+  exit 0
 fi
 docker-credential-gcr "$@"


### PR DESCRIPTION
The original solution required running docker-credential-gcr gcr-login manually, which was a poor solution.